### PR TITLE
 feat(exclamation-points): Implement textlint-rule-google-possessives

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ textlint --rule preset-google-developer README.md
     - [ ] Use quoted text
     - [ ] Punctuation and spacing
 - [Exclamation points](https://developers.google.com/style/exclamation-points)
-    - [ ] Don't use `!` and `?`
+    - :heavy_check_mark: `textlint-rule-google-possessives`
+    - [x] Don't use `!` and `?`
 - [Hyphens](https://developers.google.com/style/hyphens)
     - [ ] Don't hyphenate adverbs ending in "ly" 
     - [ ] Don't add words such as -from- or -between-.

--- a/packages/textlint-rule-google-exclamation-points/LICENSE
+++ b/packages/textlint-rule-google-exclamation-points/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/textlint-rule-google-exclamation-points/README.md
+++ b/packages/textlint-rule-google-exclamation-points/README.md
@@ -1,0 +1,59 @@
+# textlint-rule-google-exclamation-points
+
+Reference https://developers.google.com/style/exclamation-points
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install textlint-rule-google-exclamation-points
+
+## Usage
+
+Via `.textlintrc`(Recommended)
+
+```json
+{
+    "rules": {
+        "google-exclamation-points": true
+    }
+}
+```
+
+Via CLI
+
+```
+textlint --rule google-exclamation-points README.md
+```
+
+
+## Changelog
+
+See [Releases page](https://github.com/textlint-rule/textlint-rule-preset-google/releases).
+
+## Running tests
+
+Install devDependencies and Run `npm test`:
+
+    npm i -d && npm test
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/textlint-rule/textlint-rule-preset-google/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## Author
+
+- [github/azu](https://github.com/azu)
+- [twitter/azu_re](https://twitter.com/azu_re)
+
+## License
+
+MIT © azu

--- a/packages/textlint-rule-google-exclamation-points/README.md
+++ b/packages/textlint-rule-google-exclamation-points/README.md
@@ -1,6 +1,10 @@
 # textlint-rule-google-exclamation-points
 
-Reference https://developers.google.com/style/exclamation-points
+Reference [Exclamation points  |  Google Developer Documentation Style Guide  |  Google Developers](https://developers.google.com/style/exclamation-points)
+
+See also:
+          
+- [azu/textlint-rule-no-exclamation-question-mark: textlint rule that disallow exclamation and question mark.](https://github.com/azu/textlint-rule-no-exclamation-question-mark)
 
 ## Install
 
@@ -24,6 +28,21 @@ Via CLI
 
 ```
 textlint --rule google-exclamation-points README.md
+```
+
+## Options
+
+```json
+{
+    // allow to use !
+    "allowHalfWidthExclamation": false,
+    // allow to use ！
+    "allowFullWidthExclamation": false,
+    // allow to use ?
+    "allowHalfWidthQuestion": false,
+    // allow to use ？
+    "allowFullWidthQuestion": false
+}
 ```
 
 

--- a/packages/textlint-rule-google-exclamation-points/package.json
+++ b/packages/textlint-rule-google-exclamation-points/package.json
@@ -1,0 +1,43 @@
+{
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "author": "azu",
+  "license": "MIT",
+  "files": [
+    "bin/",
+    "lib/",
+    "src/"
+  ],
+  "name": "textlint-rule-google-exclamation-points",
+  "version": "1.0.0",
+  "description": "Reference https://developers.google.com/style/exclamation-points",
+  "main": "lib/textlint-rule-google-exclamation-points.js",
+  "scripts": {
+    "test": "textlint-scripts test",
+    "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,css}'",
+    "prepublish": "npm run --if-present build",
+    "build": "textlint-scripts build",
+    "watch": "textlint-scripts build --watch"
+  },
+  "keywords": [
+    "textlintrule"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/textlint-rule/textlint-rule-preset-google.git"
+  },
+  "bugs": {
+    "url": "https://github.com/textlint-rule/textlint-rule-preset-google/issues"
+  },
+  "homepage": "https://github.com/textlint-rule/textlint-rule-preset-google/tree/master/packages/textlint-rule-google-exclamation-points/",
+  "devDependencies": {
+    "prettier": "^1.7.4",
+    "textlint-scripts": "^1.2.4"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "tabWidth": 4
+  }
+}

--- a/packages/textlint-rule-google-exclamation-points/package.json
+++ b/packages/textlint-rule-google-exclamation-points/package.json
@@ -39,5 +39,8 @@
   "prettier": {
     "printWidth": 120,
     "tabWidth": 4
+  },
+  "dependencies": {
+    "textlint-rule-no-exclamation-question-mark": "^1.0.2"
   }
 }

--- a/packages/textlint-rule-google-exclamation-points/src/textlint-rule-google-exclamation-points.js
+++ b/packages/textlint-rule-google-exclamation-points/src/textlint-rule-google-exclamation-points.js
@@ -1,0 +1,2 @@
+// MIT © 2017 azu
+"use strict";

--- a/packages/textlint-rule-google-exclamation-points/src/textlint-rule-google-exclamation-points.js
+++ b/packages/textlint-rule-google-exclamation-points/src/textlint-rule-google-exclamation-points.js
@@ -1,2 +1,23 @@
 // MIT © 2017 azu
 "use strict";
+const noExclamationQuestionMark = require("textlint-rule-no-exclamation-question-mark");
+const defaultOptions = {
+    // allow to use !
+    "allowHalfWidthExclamation": false,
+    // allow to use ！
+    "allowFullWidthExclamation": false,
+    // allow to use ?
+    "allowHalfWidthQuestion": false,
+    // allow to use ？
+    "allowFullWidthQuestion": false
+};
+const linter = (context, options = defaultOptions) => {
+    const {RuleError, report} = context;
+    return noExclamationQuestionMark(Object.assign({}, context, {
+        report: (node, error) => {
+            error.message += "\nhttps://developers.google.com/style/exclamation-points";
+            report(node, error);
+        }
+    }), options);
+};
+module.exports = linter;

--- a/packages/textlint-rule-google-exclamation-points/test/textlint-rule-google-exclamation-points-test.js
+++ b/packages/textlint-rule-google-exclamation-points/test/textlint-rule-google-exclamation-points-test.js
@@ -1,0 +1,18 @@
+// MIT © 2017 azu
+"use strict";
+const noExclamationQuestionMark = require("textlint-rule-no-exclamation-question-mark");
+const report = context => {
+    const {Syntax, RuleError, fixer, report} = context;
+    const Types = noExclamationQuestionMark(context);
+    return {
+        [Syntax.Str](node){
+            const result = Types[Syntax.Str](node);
+            console.log(result);
+            return result;
+        }
+    }
+};
+module.exports = {
+    linter: report,
+    fixer: report
+};

--- a/packages/textlint-rule-google-exclamation-points/test/textlint-rule-google-exclamation-points-test.js
+++ b/packages/textlint-rule-google-exclamation-points/test/textlint-rule-google-exclamation-points-test.js
@@ -1,18 +1,77 @@
-// MIT © 2017 azu
-"use strict";
-const noExclamationQuestionMark = require("textlint-rule-no-exclamation-question-mark");
-const report = context => {
-    const {Syntax, RuleError, fixer, report} = context;
-    const Types = noExclamationQuestionMark(context);
-    return {
-        [Syntax.Str](node){
-            const result = Types[Syntax.Str](node);
-            console.log(result);
-            return result;
+const TextLintTester = require("textlint-tester");
+const tester = new TextLintTester();
+// rule
+const rule = require("../src/textlint-rule-google-exclamation-points");
+const URL = "\nhttps://developers.google.com/style/exclamation-points";
+tester.run("textlint-rule-google-contractions", rule, {
+    valid: ["Don't use exclamation points in text except when they're part of a code example."],
+    invalid: [
+        // single match
+        {
+            text: "Hey!",
+            errors: [
+                {
+                    message: `Disallow to use "!".` + URL,
+                    line: 1,
+                    column: 4
+                }
+            ]
+        },
+        // multiple match in multiple lines
+        {
+            text: "Hey!?\nHey！？",
+            errors: [
+                {
+                    message: `Disallow to use "!".` + URL,
+                    line: 1,
+                    column: 4
+                },
+                {
+                    message: `Disallow to use "?".` + URL,
+                    line: 1,
+                    column: 5
+                },
+                {
+                    message: `Disallow to use "！".` + URL,
+                    line: 2,
+                    column: 4
+                },
+                {
+                    message: `Disallow to use "？".` + URL,
+                    line: 2,
+                    column: 5
+                }
+            ]
+        },
+        // multiple hit items in a line
+        {
+            text: "Hey!?",
+            errors: [
+                {
+                    message: `Disallow to use "!".` + URL,
+                    line: 1,
+                    column: 4
+                },
+                {
+                    message: `Disallow to use "?".` + URL,
+                    line: 1,
+                    column: 5
+                }
+            ]
+        },
+        // Allow Option: !
+        {
+            text: "Hey!?",
+            options: {
+                allowHalfWidthExclamation: true
+            },
+            errors: [
+                {
+                    message: `Disallow to use "?".`,
+                    line: 1,
+                    column: 5
+                }
+            ]
         }
-    }
-};
-module.exports = {
-    linter: report,
-    fixer: report
-};
+    ]
+});

--- a/packages/textlint-rule-google-exclamation-points/test/textlint-rule-google-exclamation-points-test.js
+++ b/packages/textlint-rule-google-exclamation-points/test/textlint-rule-google-exclamation-points-test.js
@@ -67,7 +67,7 @@ tester.run("textlint-rule-google-contractions", rule, {
             },
             errors: [
                 {
-                    message: `Disallow to use "?".`,
+                    message: `Disallow to use "?".` + URL,
                     line: 1,
                     column: 5
                 }

--- a/packages/textlint-rule-google-possessives/src/textlint-rule-google-possessives.js
+++ b/packages/textlint-rule-google-possessives/src/textlint-rule-google-possessives.js
@@ -34,7 +34,6 @@ const report = context => {
                 // if "the word's", ignore this
                 if (determinerWord !== undefined) {
                     const determinerType = getPosFromSingleWord(determinerWord);
-                    console.log(determinerType);
                     // skip: the a
                     if (determinerType === "DT") {
                         return false;


### PR DESCRIPTION
Implement [Exclamation points  |  Google Developer Documentation Style Guide  |  Google Developers](https://developers.google.com/style/exclamation-points)
using [azu/textlint-rule-no-exclamation-question-mark: textlint rule that disallow exclamation and question mark.](https://github.com/azu/textlint-rule-no-exclamation-question-mark)
