### PR TITLE
feat(plurals-parentheses): add textlint-rule-google-plurals-parentheses

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ textlint --rule preset-google-developer README.md
     - [x] Don't use double contractions
 - [Cross-references](https://developers.google.com/style/cross-references)
 - [Plurals in parentheses](https://developers.google.com/style/plurals-parentheses)
-    - [ ] Don't put optional plurals in parentheses.
+    - :heavy_check_mark: `textlint-rule-google-plurals-parentheses`
+    - [x] Don't put optional plurals in parentheses.
 - [Prepositions](https://developers.google.com/style/prepositions)
 - [Present tense](https://developers.google.com/style/tense)
     - [ ] will

--- a/packages/textlint-rule-google-plurals-parentheses/LICENSE
+++ b/packages/textlint-rule-google-plurals-parentheses/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2017 azu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/textlint-rule-google-plurals-parentheses/README.md
+++ b/packages/textlint-rule-google-plurals-parentheses/README.md
@@ -1,6 +1,6 @@
 # @textlint-rule/textlint-rule-google-plurals-parentheses
 
-Reference: https://developers.google.com/style/plurals-parentheses
+Reference: [Plurals in parentheses  |  Google Developer Documentation Style Guide  |  Google Developers](https://developers.google.com/style/plurals-parentheses "Plurals in parentheses  |  Google Developer Documentation Style Guide  |  Google Developers").
 
 ## Install
 

--- a/packages/textlint-rule-google-plurals-parentheses/README.md
+++ b/packages/textlint-rule-google-plurals-parentheses/README.md
@@ -1,0 +1,59 @@
+# @textlint-rule/textlint-rule-google-plurals-parentheses
+
+Reference: https://developers.google.com/style/plurals-parentheses
+
+## Install
+
+Install with [npm](https://www.npmjs.com/):
+
+    npm install @textlint-rule/textlint-rule-google-plurals-parentheses
+
+## Usage
+
+Via `.textlintrc`(Recommended)
+
+```json
+{
+    "rules": {
+        "@textlint-rule/google-plurals-parentheses": true
+    }
+}
+```
+
+Via CLI
+
+```
+textlint --rule @textlint-rule/google-plurals-parentheses README.md
+```
+
+
+## Changelog
+
+See [Releases page](https://github.com/textlint-rule/textlint-rule-preset-google/releases).
+
+## Running tests
+
+Install devDependencies and Run `npm test`:
+
+    npm i -d && npm test
+
+## Contributing
+
+Pull requests and stars are always welcome.
+
+For bugs and feature requests, [please create an issue](https://github.com/textlint-rule/textlint-rule-preset-google/issues).
+
+1. Fork it!
+2. Create your feature branch: `git checkout -b my-new-feature`
+3. Commit your changes: `git commit -am 'Add some feature'`
+4. Push to the branch: `git push origin my-new-feature`
+5. Submit a pull request :D
+
+## Author
+
+- [github/azu](https://github.com/azu)
+- [twitter/azu_re](https://twitter.com/azu_re)
+
+## License
+
+MIT © azu

--- a/packages/textlint-rule-google-plurals-parentheses/package.json
+++ b/packages/textlint-rule-google-plurals-parentheses/package.json
@@ -1,0 +1,46 @@
+{
+  "directories": {
+    "lib": "lib",
+    "test": "test"
+  },
+  "author": "azu",
+  "license": "MIT",
+  "files": [
+    "bin/",
+    "lib/",
+    "src/"
+  ],
+  "name": "@textlint-rule/textlint-rule-google-plurals-parentheses",
+  "version": "1.0.0",
+  "description": "Reference: https://developers.google.com/style/plurals-parentheses",
+  "main": "lib/textlint-rule-google-plurals-parentheses.js",
+  "scripts": {
+    "test": "textlint-scripts test",
+    "prettier": "prettier --write '**/*.{js,jsx,ts,tsx,css}'",
+    "prepublish": "npm run --if-present build",
+    "build": "textlint-scripts build",
+    "watch": "textlint-scripts build --watch"
+  },
+  "keywords": [
+    "textlintrule"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/textlint-rule/textlint-rule-preset-google.git"
+  },
+  "bugs": {
+    "url": "https://github.com/textlint-rule/textlint-rule-preset-google/issues"
+  },
+  "homepage": "https://github.com/textlint-rule/textlint-rule-preset-google/tree/master/packages/textlint-rule-google-plurals-parentheses/",
+  "devDependencies": {
+    "prettier": "^1.7.4",
+    "textlint-scripts": "^1.4.0"
+  },
+  "prettier": {
+    "printWidth": 120,
+    "tabWidth": 4
+  },
+  "dependencies": {
+    "@textlint-rule/textlint-report-helper-for-google-preset": "^0.0.4"
+  }
+}

--- a/packages/textlint-rule-google-plurals-parentheses/src/textlint-rule-google-plurals-parentheses.js
+++ b/packages/textlint-rule-google-plurals-parentheses/src/textlint-rule-google-plurals-parentheses.js
@@ -1,0 +1,45 @@
+// MIT © 2017 azu
+"use strict";
+import {
+    paragraphReporter,
+    getPosFromSingleWord,
+    PosType
+} from "@textlint-rule/textlint-report-helper-for-google-preset";
+
+const DocumentURL = "https://developers.google.com/style/hyphens";
+const report = context => {
+    const dictionaries = [
+        // word(s)
+        // if "words" is plural, report as error
+        {
+            pattern: /([\w-]+)\((\w+)\)/g,
+            test: ({ captures }) => {
+                const pluralWord = `${captures[0]}${captures[1]}`;
+                const pos = getPosFromSingleWord(pluralWord);
+                return pos === PosType.PluralNoun || pos === PosType.PluralProperNoun;
+            },
+            message: () => ` Don't put optional plurals in parentheses.
+${DocumentURL}
+`
+        }
+    ];
+
+    const { Syntax, RuleError, getSource, fixer, report } = context;
+    return {
+        [Syntax.Paragraph](node) {
+            return paragraphReporter({
+                node,
+                Syntax,
+                dictionaries,
+                report,
+                getSource,
+                RuleError,
+                fixer
+            });
+        }
+    };
+};
+module.exports = {
+    linter: report,
+    fixer: report
+};

--- a/packages/textlint-rule-google-plurals-parentheses/test/textlint-rule-google-plurals-parentheses-test.js
+++ b/packages/textlint-rule-google-plurals-parentheses/test/textlint-rule-google-plurals-parentheses-test.js
@@ -1,0 +1,32 @@
+// MIT © 2017 azu
+"use strict";
+const TextLintTester = require("textlint-tester");
+const rule = require("../src/textlint-rule-google-plurals-parentheses");
+const tester = new TextLintTester();
+tester.run("textlint-rule-google-plurals-parentheses", rule, {
+    valid: [
+        "To find your API key, visit the Credentials page.",
+        "The value of the parent depends on the values of its children."
+    ],
+    invalid: [
+        {
+            text: "To find your API key(s), visit the Credentials page.",
+            errors: [
+                {
+                    index: 17
+                }
+            ]
+        },
+        {
+            text: "The value of the parent depends on the value(s) of its child(ren).",
+            errors: [
+                {
+                    index: 39
+                },
+                {
+                    index: 55
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
Implement [Plurals in parentheses  |  Google Developer Documentation Style Guide  |  Google Developers](https://developers.google.com/style/plurals-parentheses "Plurals in parentheses  |  Google Developer Documentation Style Guide  |  Google Developers")