### PR TITLE
Feature/add wordlist option

### DIFF
--- a/packages/textlint-rule-google-word-list/src/textlint-rule-google-word-list.js
+++ b/packages/textlint-rule-google-word-list/src/textlint-rule-google-word-list.js
@@ -2,7 +2,9 @@
 "use strict";
 import { paragraphReporter, getPosFromSingleWord } from "@textlint-rule/textlint-report-helper-for-google-preset";
 
-const report = context => {
+const report = (context, options = {}) => {
+    const allowWords = Array.isArray(options.allowWords) ? options.allowWords : [];
+
     // Politeness and use of "please"
     // https://developers.google.com/style/tone#politeness-and-use-of-please
     const dictionaries = [
@@ -276,7 +278,8 @@ const report = context => {
             replace: preDict.replace ? preDict.replace : undefined,
             message: () => preDict.message
         };
-    });
+    })
+    .filter(({ pattern }) => !allowWords.some(word => pattern.test(word)));
 
     const { Syntax, RuleError, getSource, fixer, report } = context;
     return {

--- a/packages/textlint-rule-google-word-list/src/textlint-rule-google-word-list.js
+++ b/packages/textlint-rule-google-word-list/src/textlint-rule-google-word-list.js
@@ -271,15 +271,16 @@ const report = (context, options = {}) => {
             message:
                 "Don't use to refer to expander arrows,\nunless you're specifically referring to the Zippy\nwidget in Closure."
         }
-    ].map(preDict => {
-        return {
-            pattern: typeof preDict.word === "string" ? new RegExp("\\b" + preDict.word + "\\b") : preDict.word,
-            test: preDict.test ? preDict.test : undefined,
-            replace: preDict.replace ? preDict.replace : undefined,
-            message: () => preDict.message
-        };
-    })
-    .filter(({ pattern }) => !allowWords.some(word => pattern.test(word)));
+    ]
+        .map(preDict => {
+            return {
+                pattern: typeof preDict.word === "string" ? new RegExp("\\b" + preDict.word + "\\b") : preDict.word,
+                test: preDict.test ? preDict.test : undefined,
+                replace: preDict.replace ? preDict.replace : undefined,
+                message: () => preDict.message
+            };
+        })
+        .filter(({ pattern }) => !allowWords.some(word => pattern.test(word)));
 
     const { Syntax, RuleError, getSource, fixer, report } = context;
     return {

--- a/packages/textlint-rule-google-word-list/test/textlint-rule-google-word-list-test.js
+++ b/packages/textlint-rule-google-word-list/test/textlint-rule-google-word-list-test.js
@@ -193,7 +193,12 @@ tester.run("textlint-rule-google-word-list", rule, {
         "with",
         "zip",
         // allow
-        "touch & hold is ok"
+        "touch & hold is ok",
+        // with option: allowList
+        {
+            text: "This is an application.",
+            options: { allowWords: ['application'] }
+        }
     ],
     invalid: [
         {
@@ -217,6 +222,22 @@ tester.run("textlint-rule-google-word-list", rule, {
         {
             text: "administrator",
             output: "admin",
+            errors: [{}]
+        },
+        // with option: allowList
+        {
+            text: "This is an application.",
+            options: { allowWords: []},
+            output: "This is an app.",
+            errors: [{}]
+        },
+        {
+            text: "This is an application.",
+            options: { allowWords: [
+                // 'application'
+                'app',
+            ]},
+            output: "This is an app.",
             errors: [{}]
         }
     ]

--- a/packages/textlint-rule-google-word-list/test/textlint-rule-google-word-list-test.js
+++ b/packages/textlint-rule-google-word-list/test/textlint-rule-google-word-list-test.js
@@ -197,7 +197,7 @@ tester.run("textlint-rule-google-word-list", rule, {
         // with option: allowList
         {
             text: "This is an application.",
-            options: { allowWords: ['application'] }
+            options: { allowWords: ["application"] }
         }
     ],
     invalid: [
@@ -227,16 +227,18 @@ tester.run("textlint-rule-google-word-list", rule, {
         // with option: allowList
         {
             text: "This is an application.",
-            options: { allowWords: []},
+            options: { allowWords: [] },
             output: "This is an app.",
             errors: [{}]
         },
         {
             text: "This is an application.",
-            options: { allowWords: [
-                // 'application'
-                'app',
-            ]},
+            options: {
+                allowWords: [
+                    // 'application'
+                    "app"
+                ]
+            },
             output: "This is an app.",
             errors: [{}]
         }


### PR DESCRIPTION
Added `allowList` option (as well as `capitalization`) to allow prohibited words in static wording dictionary.